### PR TITLE
Add python2.7 support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,10 +13,6 @@ import setuptools
 from setuptools.command.test import test as TestCommand
 from setuptools import setup
 
-if sys.version_info < (3, 4, 0):
-    sys.stderr.write('FATAL: STUPS needs to be run with Python 3.4+\n')
-    sys.exit(1)
-
 __location__ = os.path.join(os.getcwd(), os.path.dirname(inspect.getfile(inspect.currentframe())))
 
 

--- a/stups_cli/config.py
+++ b/stups_cli/config.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 import click
 import dns.exception
 import dns.resolver
@@ -16,9 +18,9 @@ def get_path(section):
 
 
 def load_config(section):
-    '''Get configuration for given section/project
+    """Get configuration for given section/project
 
-    Tries to load YAML configuration file and also considers environment variables'''
+    Tries to load YAML configuration file and also considers environment variables"""
     path = get_path(section)
     try:
         with open(path, 'rb') as fd:
@@ -42,7 +44,7 @@ def store_config(config, section):
     try:
         with open(path, 'w') as fd:
             yaml.safe_dump(config, fd)
-    except PermissionError:
+    except IOError:
         # we ignore permission errors here as users might make their config file readonly
         # to prevent corrupt files when running multiple processes
         pass
@@ -111,7 +113,7 @@ def configure(preselected_domain=None):
                 store_config({'domain': domain}, 'stups')
             with Action('Writing config for Pier One..'):
                 store_config({'url': urls['pierone']}, 'pierone')
-            with Action('Writing config for Più..'):
+            with Action(u'Writing config for Più..'):
                 store_config({'even_url': urls['even']}, 'piu')
             with Action('Writing config for Fullstop..'):
                 store_config({'url': urls['fullstop']}, 'fullstop')


### PR DESCRIPTION
We need python2 support for our project, which uses stups-zign and this is a dependancy.
There is no real need in restricting to Python >=3.4, it's easy to make it working for Python 2.