### PR TITLE
ignore new flake8 "do not use bare except"

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,2 +1,3 @@
 [flake8]
 max-line-length=120
+ignore=E722


### PR DESCRIPTION
A new flake8 warning was introduced, ignore it to make the CD pipeline work:

```
$ flake8 
./setup.py:87:9: E722 do not use bare except'
./stups_cli/config.py:26:5: E722 do not use bare except'
./stups_cli/config.py:55:5: E722 do not use bare except'
./stups_cli/config.py:97:17: E722 do not use bare except'
